### PR TITLE
Add Python 3.7 classifier and Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,30 @@
 language: python
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
 install:
   - if test `python --version 2>&1 | cut -d " " -f 2 | cut -d "." -f 1`  = 3; then pip install -r requirements.txt; fi
 script:
   - python -m unittest test_asserts
   - if test `python --version 2>&1 | cut -d " " -f 2 | cut -d "." -f 1`  = 3; then mypy asserts test_asserts.py; fi
   - if test `python --version 2>&1 | cut -d " " -f 2 | cut -d "." -f 1`  = 3; then python -m doctest asserts/__init__.py; fi
+jobs:
+  include:
+    - stage: test
+      python: 2.7
+      dist: trusty
+      sudo: false
+    - stage: test
+      python: 3.4
+      dist: trusty
+      sudo: false
+    - stage: test
+      python: 3.5
+      dist: trusty
+      sudo: false
+    - stage: test
+      python: 3.6
+      dist: trusty
+      sudo: false
+    - stage: test
+      python: 3.7
+      dist: xenial
+      sudo: true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 install:
   - if test `python --version 2>&1 | cut -d " " -f 2 | cut -d "." -f 1`  = 3; then pip install -r requirements.txt; fi
 script:

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Quality Assurance",
         "Topic :: Software Development :: Testing",
     ],


### PR DESCRIPTION
All unit tests pass on Python 3.7 so the Python 3.7 classifier can safely be added to setup.py.